### PR TITLE
Make pycanberra work with both Python 2 and 3

### DIFF
--- a/pycanberra.py
+++ b/pycanberra.py
@@ -6,6 +6,18 @@
 from ctypes import *
 import time
 
+# This is inspired by the six module: http://pypi.python.org/pypi/six
+import sys
+if sys.version_info.major == 3:
+    string_types = str,
+    def b(s):
+        return s.encode("latin-1")
+else:
+    string_types = basestring,
+    def b(s):
+        return s
+
+
 # /**
 #  * CA_PROP_MEDIA_NAME:
 #  *
@@ -556,6 +568,8 @@ class Canberra(object):
          raise CanberraException(res, "Failed to destroy context")
 
    def change_props(self, *args):
+      args = tuple(b(arg) if isinstance(arg, string_types) else arg
+                   for arg in args)
       res = GetApi().ca_context_change_props(self._handle, *args)
       if res != CA_SUCCESS:
          raise CanberraException(res, "Failed to change props")
@@ -573,11 +587,15 @@ class Canberra(object):
       pass
 
    def play(self, playId, *args):
+      args = tuple(b(arg) if isinstance(arg, string_types) else arg
+                   for arg in args)
       res = GetApi().ca_context_play(self._handle, playId, *args)
       if res != CA_SUCCESS:
          raise CanberraException(res, "Failed to play!")
 
    def cache(self, *args):
+      args = tuple(b(arg) if isinstance(arg, string_types) else arg
+                   for arg in args)
       res = GetApi().ca_context_cache(self._handle, *args)
       if res != CA_SUCCESS:
          raise CanberraException(res, "Failed to cache")
@@ -596,6 +614,8 @@ class Canberra(object):
 
    def easy_play_sync(self, eventName):
       """ play an event sound synchronously """
+      if isinstance(eventName, string_types):
+          eventName = b(eventName)
       self.play(1,
                 CA_PROP_EVENT_ID, eventName,
                 None)

--- a/pycanberra.py
+++ b/pycanberra.py
@@ -4,7 +4,6 @@
 # License: LGPL 2.1
 ##########################################################################
 from ctypes import *
-import exceptions
 import time
 
 # /**
@@ -519,16 +518,16 @@ def GetApi():
 # int ca_proplist_set(ca_proplist *p, const char *key, const void *data, size_t nbytes);
 
 
-class CanberraException(exceptions.Exception):
+class CanberraException(Exception):
    def __init__(self, err, *args, **kwargs):
       self._err = err
-      super(exceptions.Exception, self).__init__(*args, **kwargs)
+      super(Exception, self).__init__(*args, **kwargs)
 
    def get_error(self):
       return self._err
 
    def __str__(self):
-      return super(exceptions.Exception, self).__str__() + " (error %d)" % self._err
+      return super(Exception, self).__str__() + " (error %d)" % self._err
    
 
 class Canberra(object):


### PR DESCRIPTION
The first commit is just clean up, it removes something that already wasn't needed in Python 2. However, from unneeded in Python 2, it becomes problematic in Python 3, so it should be dropped.

The second commit makes pycanberra work on Python 3, using the [six](http://pypi.python.org/pypi/six) library to keep it compatible with Python 2.

The issue is on strings defined as `"foo"` which were byte strings in Python 2 but became unicode strings in Python 3.

The underlying C libcanberra doesn't accept unicode strings, so they all must be byte strings.

However, defining them with `b"foo"` would break them on Python 2, so I used `six.b("foo")` instead.

If the dependency on `six` is an issue, then we could just copy-paste the code for `six.b` in pycanberra. (but code duplication is bad, so I preferred using the module as a dependency in the first submission :wink:)
